### PR TITLE
Upgrade React Native and the uploader packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ The express server that receives the upload and writes it to file.
 ## Common issues
 
  1. If your server is not getting hit `adb reverse tcp:3000 tcp:3000`
+
+## Working on the react-native-background-upload package
+
+If you are using this app to make changes to the react-native-background-upload package, you'll probably need to use the react-native-background-upload package from your file system and not from npm.  To do this, edit the package.json to replace the existing version from npm like so:
+```
+"react-native-background-upload": "file:../react-native-background-upload",
+```
+Remember not to push this to github because it'll work for you but nobody else.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ of a bug or other issue when opening up a github issue on
  1. Run the example app `react-native run-ios` or `react-native run-android`
  1. Tap the button in the mobile app to perform an upload.
 
+If you are running on an Android device connected via USB, run `adb reverse tcp:3000 tcp:3000` after `react-native run-android`.  This will allow the device to communicate with the server.  Otherwise it won't work.
+
 ## Important files to look at
 
 ### [js/components/Upload.js](https://github.com/Vydia/ReactNativeBackgroundUploadExample/blob/master/js/components/Upload.js)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -130,7 +130,6 @@ android {
             }
         }
     }
-    configurations.all { resolutionStrategy.force 'com.squareup.okhttp3:okhttp:3.4.1' }
 }
 
 dependencies {

--- a/ios/ReactNativeBackgroundUploadExample.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeBackgroundUploadExample.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -24,7 +25,7 @@
 		2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		2D02E4BD1E0B4A84006451C7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		2D02E4C21E0B4AEC006451C7 /* libRCTAnimation-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157351DD0AC6500FF2AA8 /* libRCTAnimation-tvOS.a */; };
+		2D02E4C21E0B4AEC006451C7 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157351DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		2D02E4C31E0B4AEC006451C7 /* libRCTImage-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E841DF850E9000B6D8A /* libRCTImage-tvOS.a */; };
 		2D02E4C41E0B4AEC006451C7 /* libRCTLinking-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E881DF850E9000B6D8A /* libRCTLinking-tvOS.a */; };
 		2D02E4C51E0B4AEC006451C7 /* libRCTNetwork-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E8C1DF850E9000B6D8A /* libRCTNetwork-tvOS.a */; };
@@ -35,8 +36,8 @@
 		2DCD954D1E0B4F2C00145EB5 /* ReactNativeBackgroundUploadExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* ReactNativeBackgroundUploadExampleTests.m */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
-		EC1ACF727C2C44EE84D286FD /* libVydiaRNFileUploader.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F71D907494834406A9619B78 /* libVydiaRNFileUploader.a */; };
 		844418E620724F7A9FF6E5BD /* libRNImagePicker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D6F6EAD75EBA4F759988F102 /* libRNImagePicker.a */; };
+		EC1ACF727C2C44EE84D286FD /* libVydiaRNFileUploader.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F71D907494834406A9619B78 /* libVydiaRNFileUploader.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -229,6 +230,90 @@
 			remoteGlobalIDString = 58B5119B1A9E6C1200147676;
 			remoteInfo = RCTText;
 		};
+		DC640BBE2024B4950073D026 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3DBE0D001F3B181A0099AA32;
+			remoteInfo = fishhook;
+		};
+		DC640BC02024B4950073D026 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3DBE0D0D1F3B181C0099AA32;
+			remoteInfo = "fishhook-tvOS";
+		};
+		DC640BD22024B4950073D026 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EBF21BDC1FC498900052F4D5;
+			remoteInfo = jsinspector;
+		};
+		DC640BD42024B4950073D026 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EBF21BFA1FC4989A0052F4D5;
+			remoteInfo = "jsinspector-tvOS";
+		};
+		DC640BD62024B4950073D026 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 139D7ECE1E25DB7D00323FB7;
+			remoteInfo = "third-party";
+		};
+		DC640BD82024B4950073D026 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D383D3C1EBD27B6005632C8;
+			remoteInfo = "third-party-tvOS";
+		};
+		DC640BDA2024B4950073D026 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 139D7E881E25C6D100323FB7;
+			remoteInfo = "double-conversion";
+		};
+		DC640BDC2024B4950073D026 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D383D621EBD27B9005632C8;
+			remoteInfo = "double-conversion-tvOS";
+		};
+		DC640BDE2024B4950073D026 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9936F3131F5F2E4B0010BF04;
+			remoteInfo = privatedata;
+		};
+		DC640BE02024B4950073D026 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9936F32F1F5F2E5B0010BF04;
+			remoteInfo = "privatedata-tvOS";
+		};
+		DC640BE72024B4950073D026 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA6BC481E0AD41FEB345E281 /* RNImagePicker.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 014A3B5C1C6CF33500B6D375;
+			remoteInfo = RNImagePicker;
+		};
+		DC640BEA2024B4950073D026 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D7A10111E60F4D0EAD6D9584 /* VydiaRNFileUploader.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 014A3B5C1C6CF33500B6D375;
+			remoteInfo = VydiaRNFileUploader;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -256,10 +341,10 @@
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
-		D7A10111E60F4D0EAD6D9584 /* VydiaRNFileUploader.xcodeproj */ = {isa = PBXFileReference; name = "VydiaRNFileUploader.xcodeproj"; path = "../node_modules/react-native-background-upload/ios/VydiaRNFileUploader.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		F71D907494834406A9619B78 /* libVydiaRNFileUploader.a */ = {isa = PBXFileReference; name = "libVydiaRNFileUploader.a"; path = "libVydiaRNFileUploader.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		DA6BC481E0AD41FEB345E281 /* RNImagePicker.xcodeproj */ = {isa = PBXFileReference; name = "RNImagePicker.xcodeproj"; path = "../node_modules/react-native-image-picker/ios/RNImagePicker.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		D6F6EAD75EBA4F759988F102 /* libRNImagePicker.a */ = {isa = PBXFileReference; name = "libRNImagePicker.a"; path = "libRNImagePicker.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		D6F6EAD75EBA4F759988F102 /* libRNImagePicker.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNImagePicker.a; sourceTree = "<group>"; };
+		D7A10111E60F4D0EAD6D9584 /* VydiaRNFileUploader.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = VydiaRNFileUploader.xcodeproj; path = "../node_modules/react-native-background-upload/ios/VydiaRNFileUploader.xcodeproj"; sourceTree = "<group>"; };
+		DA6BC481E0AD41FEB345E281 /* RNImagePicker.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNImagePicker.xcodeproj; path = "../node_modules/react-native-image-picker/ios/RNImagePicker.xcodeproj"; sourceTree = "<group>"; };
+		F71D907494834406A9619B78 /* libVydiaRNFileUploader.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libVydiaRNFileUploader.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -296,7 +381,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2D02E4C91E0B4AEC006451C7 /* libReact.a in Frameworks */,
-				2D02E4C21E0B4AEC006451C7 /* libRCTAnimation-tvOS.a in Frameworks */,
+				2D02E4C21E0B4AEC006451C7 /* libRCTAnimation.a in Frameworks */,
 				2D02E4C31E0B4AEC006451C7 /* libRCTImage-tvOS.a in Frameworks */,
 				2D02E4C41E0B4AEC006451C7 /* libRCTLinking-tvOS.a in Frameworks */,
 				2D02E4C51E0B4AEC006451C7 /* libRCTNetwork-tvOS.a in Frameworks */,
@@ -389,6 +474,8 @@
 			children = (
 				139FDEF41B06529B00C62182 /* libRCTWebSocket.a */,
 				3DAD3E991DF850E9000B6D8A /* libRCTWebSocket-tvOS.a */,
+				DC640BBF2024B4950073D026 /* libfishhook.a */,
+				DC640BC12024B4950073D026 /* libfishhook-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -418,6 +505,14 @@
 				3DAD3EAB1DF850E9000B6D8A /* libcxxreact.a */,
 				3DAD3EAD1DF850E9000B6D8A /* libjschelpers.a */,
 				3DAD3EAF1DF850E9000B6D8A /* libjschelpers.a */,
+				DC640BD32024B4950073D026 /* libjsinspector.a */,
+				DC640BD52024B4950073D026 /* libjsinspector-tvOS.a */,
+				DC640BD72024B4950073D026 /* libthird-party.a */,
+				DC640BD92024B4950073D026 /* libthird-party.a */,
+				DC640BDB2024B4950073D026 /* libdouble-conversion.a */,
+				DC640BDD2024B4950073D026 /* libdouble-conversion.a */,
+				DC640BDF2024B4950073D026 /* libprivatedata.a */,
+				DC640BE12024B4950073D026 /* libprivatedata-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -426,7 +521,7 @@
 			isa = PBXGroup;
 			children = (
 				5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */,
-				5E9157351DD0AC6500FF2AA8 /* libRCTAnimation-tvOS.a */,
+				5E9157351DD0AC6500FF2AA8 /* libRCTAnimation.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -476,6 +571,7 @@
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				00E356EF1AD99517003FC87E /* ReactNativeBackgroundUploadExampleTests */,
 				83CBBA001A601CBA00E9B192 /* Products */,
+				DC640BAA2024B4900073D026 /* Recovered References */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -488,6 +584,31 @@
 				00E356EE1AD99517003FC87E /* ReactNativeBackgroundUploadExampleTests.xctest */,
 				2D02E47B1E0B4A5D006451C7 /* ReactNativeBackgroundUploadExample-tvOS.app */,
 				2D02E4901E0B4A5D006451C7 /* ReactNativeBackgroundUploadExample-tvOSTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		DC640BAA2024B4900073D026 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				F71D907494834406A9619B78 /* libVydiaRNFileUploader.a */,
+				D6F6EAD75EBA4F759988F102 /* libRNImagePicker.a */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		DC640BE22024B4950073D026 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DC640BEB2024B4950073D026 /* libVydiaRNFileUploader.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		DC640BE42024B4950073D026 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DC640BE82024B4950073D026 /* libRNImagePicker.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -646,6 +767,14 @@
 				{
 					ProductGroup = 146834001AC3E56700842450 /* Products */;
 					ProjectRef = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+				},
+				{
+					ProductGroup = DC640BE42024B4950073D026 /* Products */;
+					ProjectRef = DA6BC481E0AD41FEB345E281 /* RNImagePicker.xcodeproj */;
+				},
+				{
+					ProductGroup = DC640BE22024B4950073D026 /* Products */;
+					ProjectRef = D7A10111E60F4D0EAD6D9584 /* VydiaRNFileUploader.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -813,10 +942,10 @@
 			remoteRef = 5E9157321DD0AC6500FF2AA8 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		5E9157351DD0AC6500FF2AA8 /* libRCTAnimation-tvOS.a */ = {
+		5E9157351DD0AC6500FF2AA8 /* libRCTAnimation.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libRCTAnimation-tvOS.a";
+			path = libRCTAnimation.a;
 			remoteRef = 5E9157341DD0AC6500FF2AA8 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -832,6 +961,90 @@
 			fileType = archive.ar;
 			path = libRCTText.a;
 			remoteRef = 832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DC640BBF2024B4950073D026 /* libfishhook.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libfishhook.a;
+			remoteRef = DC640BBE2024B4950073D026 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DC640BC12024B4950073D026 /* libfishhook-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libfishhook-tvOS.a";
+			remoteRef = DC640BC02024B4950073D026 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DC640BD32024B4950073D026 /* libjsinspector.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libjsinspector.a;
+			remoteRef = DC640BD22024B4950073D026 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DC640BD52024B4950073D026 /* libjsinspector-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libjsinspector-tvOS.a";
+			remoteRef = DC640BD42024B4950073D026 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DC640BD72024B4950073D026 /* libthird-party.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libthird-party.a";
+			remoteRef = DC640BD62024B4950073D026 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DC640BD92024B4950073D026 /* libthird-party.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libthird-party.a";
+			remoteRef = DC640BD82024B4950073D026 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DC640BDB2024B4950073D026 /* libdouble-conversion.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libdouble-conversion.a";
+			remoteRef = DC640BDA2024B4950073D026 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DC640BDD2024B4950073D026 /* libdouble-conversion.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libdouble-conversion.a";
+			remoteRef = DC640BDC2024B4950073D026 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DC640BDF2024B4950073D026 /* libprivatedata.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libprivatedata.a;
+			remoteRef = DC640BDE2024B4950073D026 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DC640BE12024B4950073D026 /* libprivatedata-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libprivatedata-tvOS.a";
+			remoteRef = DC640BE02024B4950073D026 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DC640BE82024B4950073D026 /* libRNImagePicker.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNImagePicker.a;
+			remoteRef = DC640BE72024B4950073D026 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DC640BEB2024B4950073D026 /* libVydiaRNFileUploader.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libVydiaRNFileUploader.a;
+			remoteRef = DC640BEA2024B4950073D026 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -883,7 +1096,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/packager/react-native-xcode.sh";
+			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
 		2D02E4CB1E0B4B27006451C7 /* Bundle React Native Code And Images */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -972,24 +1185,24 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
+				);
 				INFOPLIST_FILE = ReactNativeBackgroundUploadExampleTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReactNativeBackgroundUploadExample.app/ReactNativeBackgroundUploadExample";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
-				);
 			};
 			name = Debug;
 		};
@@ -998,24 +1211,24 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
+				);
 				INFOPLIST_FILE = ReactNativeBackgroundUploadExampleTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReactNativeBackgroundUploadExample.app/ReactNativeBackgroundUploadExample";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
-				);
 			};
 			name = Release;
 		};
@@ -1025,6 +1238,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
+				);
 				INFOPLIST_FILE = ReactNativeBackgroundUploadExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -1034,10 +1251,6 @@
 				);
 				PRODUCT_NAME = ReactNativeBackgroundUploadExample;
 				VERSIONING_SYSTEM = "apple-generic";
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
-				);
 			};
 			name = Debug;
 		};
@@ -1046,6 +1259,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
+				);
 				INFOPLIST_FILE = ReactNativeBackgroundUploadExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -1055,10 +1272,6 @@
 				);
 				PRODUCT_NAME = ReactNativeBackgroundUploadExample;
 				VERSIONING_SYSTEM = "apple-generic";
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
-				);
 			};
 			name = Release;
 		};
@@ -1074,8 +1287,17 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
+				);
 				INFOPLIST_FILE = "ReactNativeBackgroundUploadExample-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -1085,15 +1307,6 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
-				);
 			};
 			name = Debug;
 		};
@@ -1109,8 +1322,17 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_NO_COMMON_BLOCKS = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
+				);
 				INFOPLIST_FILE = "ReactNativeBackgroundUploadExample-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -1120,15 +1342,6 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
-				);
 			};
 			name = Release;
 		};
@@ -1145,16 +1358,16 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "ReactNativeBackgroundUploadExample-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.REACT.ReactNativeBackgroundUploadExample-tvOSTests";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = appletvos;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReactNativeBackgroundUploadExample-tvOS.app/ReactNativeBackgroundUploadExample-tvOS";
-				TVOS_DEPLOYMENT_TARGET = 10.1;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.REACT.ReactNativeBackgroundUploadExample-tvOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReactNativeBackgroundUploadExample-tvOS.app/ReactNativeBackgroundUploadExample-tvOS";
+				TVOS_DEPLOYMENT_TARGET = 10.1;
 			};
 			name = Debug;
 		};
@@ -1171,16 +1384,16 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "ReactNativeBackgroundUploadExample-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.REACT.ReactNativeBackgroundUploadExample-tvOSTests";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = appletvos;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReactNativeBackgroundUploadExample-tvOS.app/ReactNativeBackgroundUploadExample-tvOS";
-				TVOS_DEPLOYMENT_TARGET = 10.1;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.REACT.ReactNativeBackgroundUploadExample-tvOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReactNativeBackgroundUploadExample-tvOS.app/ReactNativeBackgroundUploadExample-tvOS";
+				TVOS_DEPLOYMENT_TARGET = 10.1;
 			};
 			name = Release;
 		};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,8038 @@
+{
+	"name": "ReactNativeBackgroundUploadExample",
+	"version": "0.0.1",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"abab": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+			"dev": true
+		},
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+			"dev": true
+		},
+		"absolute-path": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz",
+			"integrity": "sha1-p4di+9rftSl76ZsV01p4Wy8JW/c="
+		},
+		"accepts": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+			"integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+			"requires": {
+				"mime-types": "2.1.17",
+				"negotiator": "0.6.1"
+			}
+		},
+		"acorn": {
+			"version": "4.0.13",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+			"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+			"dev": true
+		},
+		"acorn-globals": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+			"dev": true,
+			"requires": {
+				"acorn": "4.0.13"
+			}
+		},
+		"ajv": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+			"integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.0.0",
+				"json-schema-traverse": "0.3.1",
+				"json-stable-stringify": "1.0.1"
+			}
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
+		},
+		"ansi": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+		},
+		"ansi-align": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+			"dev": true,
+			"requires": {
+				"string-width": "2.1.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"ansi-escapes": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+			"dev": true
+		},
+		"ansi-gray": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+		},
+		"anymatch": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+			"integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+			"requires": {
+				"micromatch": "2.3.11",
+				"normalize-path": "2.1.1"
+			}
+		},
+		"append-field": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz",
+			"integrity": "sha1-bdxY+gg8e8VF08WZWygwzCNm1Eo="
+		},
+		"append-transform": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+			"dev": true,
+			"requires": {
+				"default-require-extensions": "1.0.0"
+			}
+		},
+		"arch": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/arch/-/arch-2.1.0.tgz",
+			"integrity": "sha1-NhOqRhSQZLPB8GB5Gb8dR4boKIk="
+		},
+		"are-we-there-yet": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+			"requires": {
+				"delegates": "1.0.0",
+				"readable-stream": "2.3.3"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
+		"argparse": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+		},
+		"array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"art": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/art/-/art-0.10.1.tgz",
+			"integrity": "sha1-OFQYg+OZIlxeGT/yRujxV897IUY="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"async": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+			"integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+			"requires": {
+				"lodash": "4.17.4"
+			}
+		},
+		"async-each": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			}
+		},
+		"babel-core": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.0",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.0",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.4",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.7",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+				}
+			}
+		},
+		"babel-generator": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+			"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+			"requires": {
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.4",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
+			}
+		},
+		"babel-helper-builder-binary-assignment-operator-visitor": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"requires": {
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-builder-react-jsx": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
+			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"esutils": "2.0.2"
+			}
+		},
+		"babel-helper-call-delegate": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"requires": {
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-define-map": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-helper-explode-assignable-expression": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"requires": {
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-get-function-arity": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-hoist-variables": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-optimise-call-expression": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-regex": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-helper-remap-async-to-generator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-replace-supers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"requires": {
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helpers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-jest": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
+			"integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
+			"dev": true,
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-plugin-istanbul": "4.1.5",
+				"babel-preset-jest": "20.0.3"
+			}
+		},
+		"babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-check-es2015-constants": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-external-helpers": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
+			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
+			"integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
+			"dev": true,
+			"requires": {
+				"find-up": "2.1.0",
+				"istanbul-lib-instrument": "1.8.0",
+				"test-exclude": "4.1.1"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				}
+			}
+		},
+		"babel-plugin-jest-hoist": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
+			"integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c=",
+			"dev": true
+		},
+		"babel-plugin-react-transform": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-2.0.2.tgz",
+			"integrity": "sha1-UVu/qZaJOYEULZCx+bFjXeKZUQk=",
+			"dev": true,
+			"requires": {
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-plugin-syntax-async-functions": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+		},
+		"babel-plugin-syntax-class-properties": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+		},
+		"babel-plugin-syntax-dynamic-import": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+		},
+		"babel-plugin-syntax-exponentiation-operator": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+		},
+		"babel-plugin-syntax-flow": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+		},
+		"babel-plugin-syntax-jsx": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+		},
+		"babel-plugin-syntax-object-rest-spread": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+		},
+		"babel-plugin-syntax-trailing-function-commas": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+		},
+		"babel-plugin-transform-async-to-generator": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz",
+			"integrity": "sha1-Gew2yxSGtZ+fRorfpCzhOQjKKZk=",
+			"requires": {
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-class-properties": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-plugin-syntax-class-properties": "6.13.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-arrow-functions": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-block-scoped-functions": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-block-scoping": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-plugin-transform-es2015-classes": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"requires": {
+				"babel-helper-define-map": "6.26.0",
+				"babel-helper-function-name": "6.24.1",
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-computed-properties": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-destructuring": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-for-of": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-literals": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-commonjs": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"requires": {
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-object-super": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"requires": {
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-parameters": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"requires": {
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-shorthand-properties": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-spread": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-sticky-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"requires": {
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-template-literals": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-unicode-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"requires": {
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"regexpu-core": "2.0.0"
+			}
+		},
+		"babel-plugin-transform-es3-member-expression-literals": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz",
+			"integrity": "sha1-cz00RPPsxBvvjtGmpOCWV7iWnrs=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es3-property-literals": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
+			"integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-exponentiation-operator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"requires": {
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-flow-strip-types": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"requires": {
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-object-assign": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
+			"integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-object-rest-spread": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+			"requires": {
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-react-display-name": {
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
+			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-react-jsx": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
+			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"requires": {
+				"babel-helper-builder-react-jsx": "6.26.0",
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-react-jsx-source": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"requires": {
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-regenerator": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+			"requires": {
+				"regenerator-transform": "0.10.1"
+			}
+		},
+		"babel-plugin-transform-strict-mode": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-preset-es2015-node": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-es2015-node/-/babel-preset-es2015-node-6.1.1.tgz",
+			"integrity": "sha1-YLIxVwJLDP6/OmNVTLBe4DW05V8=",
+			"requires": {
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"semver": "5.4.1"
+			}
+		},
+		"babel-preset-fbjs": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.1.4.tgz",
+			"integrity": "sha1-IvNY5mVAc6z2HkegUqd317zPA68=",
+			"requires": {
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-syntax-class-properties": "6.13.0",
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-class-properties": "6.24.1",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-object-super": "6.24.1",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-es3-member-expression-literals": "6.22.0",
+				"babel-plugin-transform-es3-property-literals": "6.22.0",
+				"babel-plugin-transform-flow-strip-types": "6.22.0",
+				"babel-plugin-transform-object-rest-spread": "6.26.0",
+				"babel-plugin-transform-react-display-name": "6.25.0",
+				"babel-plugin-transform-react-jsx": "6.24.1"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
+			"integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-jest-hoist": "20.0.3"
+			}
+		},
+		"babel-preset-react-native": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-2.0.0.tgz",
+			"integrity": "sha1-wmxwZsc5nfMJJvoDwBLvh/LM5bc=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-react-transform": "2.0.2",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-plugin-syntax-class-properties": "6.13.0",
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-class-properties": "6.24.1",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-flow-strip-types": "6.22.0",
+				"babel-plugin-transform-object-assign": "6.22.0",
+				"babel-plugin-transform-object-rest-spread": "6.26.0",
+				"babel-plugin-transform-react-display-name": "6.25.0",
+				"babel-plugin-transform-react-jsx": "6.24.1",
+				"babel-plugin-transform-react-jsx-source": "6.22.0",
+				"babel-plugin-transform-regenerator": "6.26.0",
+				"react-transform-hmr": "1.0.4"
+			}
+		},
+		"babel-register": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.1",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.4",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+					"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+				}
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"requires": {
+				"core-js": "2.5.1",
+				"regenerator-runtime": "0.11.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+					"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+				},
+				"regenerator-runtime": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+					"integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE="
+				}
+			}
+		},
+		"babel-template": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-traverse": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.2",
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.4",
+				"to-fast-properties": "1.0.3"
+			}
+		},
+		"babylon": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"base64-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+			"integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY="
+		},
+		"base64-url": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+			"integrity": "sha1-GZ/WYXAqDnt9yubgaYuwicUvbXg="
+		},
+		"basic-auth": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz",
+			"integrity": "sha1-Awk1sB3nyblKgksp8/zLdQ06UpA="
+		},
+		"basic-auth-connect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
+			"integrity": "sha1-/bC0OWLKe0BFanwrtI/hc9otISI="
+		},
+		"batch": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+			"integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"beeper": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+		},
+		"big-integer": {
+			"version": "1.6.26",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.26.tgz",
+			"integrity": "sha1-OvFnL6Ytry1eyvrPblqg0l4Cwcg="
+		},
+		"binary-extensions": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+			"integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+			"dev": true
+		},
+		"body-parser": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"requires": {
+				"bytes": "3.0.0",
+				"content-type": "1.0.4",
+				"debug": "2.6.9",
+				"depd": "1.1.1",
+				"http-errors": "1.6.2",
+				"iconv-lite": "0.4.19",
+				"on-finished": "2.3.0",
+				"qs": "6.5.1",
+				"raw-body": "2.3.2",
+				"type-is": "1.6.15"
+			}
+		},
+		"boom": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+			"requires": {
+				"hoek": "4.2.0"
+			},
+			"dependencies": {
+				"hoek": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+					"integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+				}
+			}
+		},
+		"boxen": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.1.tgz",
+			"integrity": "sha1-DxHn/jRO25OXl3/BPt5/ZNlWSB0=",
+			"dev": true,
+			"requires": {
+				"ansi-align": "2.0.0",
+				"camelcase": "4.1.0",
+				"chalk": "2.1.0",
+				"cli-boxes": "1.0.0",
+				"string-width": "2.1.1",
+				"term-size": "1.2.0",
+				"widest-line": "1.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+					"integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.4.0"
+					}
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+					"integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
+					"dev": true,
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				}
+			}
+		},
+		"bplist-creator": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
+			"integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
+			"requires": {
+				"stream-buffers": "2.2.0"
+			}
+		},
+		"bplist-parser": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+			"integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+			"requires": {
+				"big-integer": "1.6.26"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"browser-resolve": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"dev": true,
+			"requires": {
+				"resolve": "1.1.7"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
+				}
+			}
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"busboy": {
+			"version": "0.2.14",
+			"resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+			"integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+			"requires": {
+				"dicer": "0.2.5",
+				"readable-stream": "1.1.14"
+			}
+		},
+		"bytes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+		},
+		"callsites": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+			"dev": true,
+			"optional": true
+		},
+		"capture-stack-trace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+			"dev": true
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"requires": {
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
+			}
+		},
+		"chardet": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+		},
+		"chokidar": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
+			"requires": {
+				"anymatch": "1.3.2",
+				"async-each": "1.0.1",
+				"fsevents": "1.1.2",
+				"glob-parent": "2.0.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "2.0.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0"
+			}
+		},
+		"ci-info": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
+			"integrity": "sha1-R7RN8RjEjSWXtW00Ln4leRBgFxo=",
+			"dev": true
+		},
+		"cli-boxes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+			"dev": true
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"requires": {
+				"restore-cursor": "2.0.0"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+		},
+		"clipboardy": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.2.tgz",
+			"integrity": "sha512-16KrBOV7bHmHdxcQiCvfUFYVFyEah4FI8vYT1Fr7CGSA4G+xBWMEfUEQJS1hxeHGtI9ju1Bzs9uXSbj5HZKArw==",
+			"requires": {
+				"arch": "2.1.0",
+				"execa": "0.8.0"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "0.8.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+					"requires": {
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
+					}
+				}
+			}
+		},
+		"cliui": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"center-align": "0.1.3",
+				"right-align": "0.1.3",
+				"wordwrap": "0.0.2"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"clone": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"color-convert": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+		},
+		"combined-stream": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+			"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+		},
+		"compressible": {
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
+			"integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
+			"requires": {
+				"mime-db": "1.30.0"
+			}
+		},
+		"compression": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
+			"integrity": "sha1-sDuNhub4rSloPLqN+R3cb/x3s5U=",
+			"requires": {
+				"accepts": "1.2.13",
+				"bytes": "2.1.0",
+				"compressible": "2.0.12",
+				"debug": "2.2.0",
+				"on-headers": "1.0.1",
+				"vary": "1.0.1"
+			},
+			"dependencies": {
+				"accepts": {
+					"version": "1.2.13",
+					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+					"integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+					"requires": {
+						"mime-types": "2.1.17",
+						"negotiator": "0.5.3"
+					}
+				},
+				"bytes": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
+					"integrity": "sha1-rJPEEOL/ycx89LRks4KJBn9eR7Q="
+				},
+				"debug": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+					"requires": {
+						"ms": "0.7.1"
+					}
+				},
+				"ms": {
+					"version": "0.7.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+				},
+				"negotiator": {
+					"version": "0.5.3",
+					"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+					"integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
+				},
+				"vary": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+					"integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA="
+				}
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"typedarray": "0.0.6"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
+		"configstore": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+			"integrity": "sha1-CU7mYquD+tmRdnjeEU+q6o/NypA=",
+			"dev": true,
+			"requires": {
+				"dot-prop": "4.2.0",
+				"graceful-fs": "4.1.11",
+				"make-dir": "1.0.0",
+				"unique-string": "1.0.0",
+				"write-file-atomic": "2.3.0",
+				"xdg-basedir": "3.0.0"
+			},
+			"dependencies": {
+				"write-file-atomic": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+					"integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"signal-exit": "3.0.2"
+					}
+				}
+			}
+		},
+		"connect": {
+			"version": "2.30.2",
+			"resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
+			"integrity": "sha1-jam8vooFTT0xjXTf7JA7XDmhtgk=",
+			"requires": {
+				"basic-auth-connect": "1.0.0",
+				"body-parser": "1.13.3",
+				"bytes": "2.1.0",
+				"compression": "1.5.2",
+				"connect-timeout": "1.6.2",
+				"content-type": "1.0.4",
+				"cookie": "0.1.3",
+				"cookie-parser": "1.3.5",
+				"cookie-signature": "1.0.6",
+				"csurf": "1.8.3",
+				"debug": "2.2.0",
+				"depd": "1.0.1",
+				"errorhandler": "1.4.3",
+				"express-session": "1.11.3",
+				"finalhandler": "0.4.0",
+				"fresh": "0.3.0",
+				"http-errors": "1.3.1",
+				"method-override": "2.3.10",
+				"morgan": "1.6.1",
+				"multiparty": "3.3.2",
+				"on-headers": "1.0.1",
+				"parseurl": "1.3.2",
+				"pause": "0.1.0",
+				"qs": "4.0.0",
+				"response-time": "2.3.2",
+				"serve-favicon": "2.3.2",
+				"serve-index": "1.7.3",
+				"serve-static": "1.10.3",
+				"type-is": "1.6.15",
+				"utils-merge": "1.0.0",
+				"vhost": "3.0.2"
+			},
+			"dependencies": {
+				"body-parser": {
+					"version": "1.13.3",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
+					"integrity": "sha1-wIzzMMM1jhUQFqBXRvE/ApyX+pc=",
+					"requires": {
+						"bytes": "2.1.0",
+						"content-type": "1.0.4",
+						"debug": "2.2.0",
+						"depd": "1.0.1",
+						"http-errors": "1.3.1",
+						"iconv-lite": "0.4.11",
+						"on-finished": "2.3.0",
+						"qs": "4.0.0",
+						"raw-body": "2.1.7",
+						"type-is": "1.6.15"
+					}
+				},
+				"bytes": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
+					"integrity": "sha1-rJPEEOL/ycx89LRks4KJBn9eR7Q="
+				},
+				"cookie": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+					"integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU="
+				},
+				"debug": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+					"requires": {
+						"ms": "0.7.1"
+					}
+				},
+				"depd": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+					"integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+				},
+				"escape-html": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
+					"integrity": "sha1-130y+pjjjC9BroXpJ44ODmuhAiw="
+				},
+				"etag": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+					"integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+				},
+				"finalhandler": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
+					"integrity": "sha1-llpS2ejQXSuFdUhUH7ibU6JJfZs=",
+					"requires": {
+						"debug": "2.2.0",
+						"escape-html": "1.0.2",
+						"on-finished": "2.3.0",
+						"unpipe": "1.0.0"
+					}
+				},
+				"fresh": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+					"integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+				},
+				"http-errors": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+					"integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+					"requires": {
+						"inherits": "2.0.3",
+						"statuses": "1.3.1"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.11",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
+					"integrity": "sha1-LstC/SlHRJIiCaLnxATayHk9it4="
+				},
+				"mime": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+					"integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+				},
+				"ms": {
+					"version": "0.7.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+				},
+				"qs": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+					"integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc="
+				},
+				"range-parser": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+					"integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU="
+				},
+				"raw-body": {
+					"version": "2.1.7",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+					"integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
+					"requires": {
+						"bytes": "2.4.0",
+						"iconv-lite": "0.4.13",
+						"unpipe": "1.0.0"
+					},
+					"dependencies": {
+						"bytes": {
+							"version": "2.4.0",
+							"resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+							"integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+						},
+						"iconv-lite": {
+							"version": "0.4.13",
+							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+							"integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
+						}
+					}
+				},
+				"send": {
+					"version": "0.13.2",
+					"resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
+					"integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
+					"requires": {
+						"debug": "2.2.0",
+						"depd": "1.1.2",
+						"destroy": "1.0.4",
+						"escape-html": "1.0.3",
+						"etag": "1.7.0",
+						"fresh": "0.3.0",
+						"http-errors": "1.3.1",
+						"mime": "1.3.4",
+						"ms": "0.7.1",
+						"on-finished": "2.3.0",
+						"range-parser": "1.0.3",
+						"statuses": "1.2.1"
+					},
+					"dependencies": {
+						"depd": {
+							"version": "1.1.2",
+							"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+							"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+						},
+						"escape-html": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+							"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+						},
+						"statuses": {
+							"version": "1.2.1",
+							"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+							"integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg="
+						}
+					}
+				},
+				"serve-static": {
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
+					"integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
+					"requires": {
+						"escape-html": "1.0.3",
+						"parseurl": "1.3.2",
+						"send": "0.13.2"
+					},
+					"dependencies": {
+						"escape-html": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+							"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+						}
+					}
+				},
+				"utils-merge": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+					"integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+				}
+			}
+		},
+		"connect-timeout": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
+			"integrity": "sha1-3ppexh4zoStu2qt7XwYumMWZuI4=",
+			"requires": {
+				"debug": "2.2.0",
+				"http-errors": "1.3.1",
+				"ms": "0.7.1",
+				"on-headers": "1.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+					"requires": {
+						"ms": "0.7.1"
+					}
+				},
+				"http-errors": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+					"integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+					"requires": {
+						"inherits": "2.0.3",
+						"statuses": "1.3.1"
+					}
+				},
+				"ms": {
+					"version": "0.7.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+				}
+			}
+		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+		},
+		"content-type-parser": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
+			"integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ=",
+			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+		},
+		"cookie-parser": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
+			"integrity": "sha1-nXVVcPtdF4kHcSJ6AjFNm+fPg1Y=",
+			"requires": {
+				"cookie": "0.1.3",
+				"cookie-signature": "1.0.6"
+			},
+			"dependencies": {
+				"cookie": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+					"integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU="
+				}
+			}
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+		},
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"crc": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
+			"integrity": "sha1-+mIuG8OIvyVzCQgta2UgDOZwkLo="
+		},
+		"create-error-class": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"dev": true,
+			"requires": {
+				"capture-stack-trace": "1.0.0"
+			}
+		},
+		"create-react-class": {
+			"version": "15.6.2",
+			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
+			"integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				}
+			}
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"requires": {
+				"lru-cache": "4.1.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
+			}
+		},
+		"cryptiles": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+			"requires": {
+				"boom": "5.2.0"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+					"integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+					"requires": {
+						"hoek": "4.2.0"
+					}
+				},
+				"hoek": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+					"integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+				}
+			}
+		},
+		"crypto-random-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+			"dev": true
+		},
+		"csrf": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
+			"integrity": "sha1-thEg3c7q/JHnbtUxO7XAsmZ7cQo=",
+			"requires": {
+				"rndm": "1.2.0",
+				"tsscmp": "1.0.5",
+				"uid-safe": "2.1.4"
+			}
+		},
+		"cssom": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+			"dev": true
+		},
+		"cssstyle": {
+			"version": "0.2.37",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"dev": true,
+			"requires": {
+				"cssom": "0.3.2"
+			}
+		},
+		"csurf": {
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
+			"integrity": "sha1-I/KhO/HY/OHQyZZYg5RELLqGpWo=",
+			"requires": {
+				"cookie": "0.1.3",
+				"cookie-signature": "1.0.6",
+				"csrf": "3.0.6",
+				"http-errors": "1.3.1"
+			},
+			"dependencies": {
+				"cookie": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+					"integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU="
+				},
+				"http-errors": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+					"integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+					"requires": {
+						"inherits": "2.0.3",
+						"statuses": "1.3.1"
+					}
+				}
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"dateformat": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+			"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"deep-extend": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+			"dev": true
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"default-require-extensions": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+			"dev": true,
+			"requires": {
+				"strip-bom": "2.0.0"
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+		},
+		"denodeify": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
+			"integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE="
+		},
+		"depd": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+			"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+		},
+		"detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"requires": {
+				"repeating": "2.0.1"
+			}
+		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+		},
+		"dicer": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+			"integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+			"requires": {
+				"readable-stream": "1.1.14",
+				"streamsearch": "0.1.2"
+			}
+		},
+		"diff": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+			"integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
+			"dev": true
+		},
+		"dom-walk": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+		},
+		"dot-prop": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+			"integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
+			"dev": true,
+			"requires": {
+				"is-obj": "1.0.1"
+			}
+		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
+		"duplexer2": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+			"requires": {
+				"readable-stream": "1.1.14"
+			}
+		},
+		"duplexer3": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+			"dev": true
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+		},
+		"encodeurl": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+			"integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"envinfo": {
+			"version": "3.11.1",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-3.11.1.tgz",
+			"integrity": "sha512-hKkh7aKtont6Zuv4RmE4VkOc96TkBj9NXj7Ghsd/qCA9LuJI0Dh+ImwA1N5iORB9Vg+sz5bq9CHJzs51BILNCQ==",
+			"requires": {
+				"clipboardy": "1.2.2",
+				"glob": "7.1.2",
+				"minimist": "1.2.0",
+				"os-name": "2.0.1",
+				"which": "1.3.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"errno": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+			"dev": true,
+			"requires": {
+				"prr": "0.0.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"requires": {
+				"is-arrayish": "0.2.1"
+			}
+		},
+		"errorhandler": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
+			"integrity": "sha1-t7cO2PNZ6duICS8tIMD4MUIK2D8=",
+			"requires": {
+				"accepts": "1.3.4",
+				"escape-html": "1.0.3"
+			}
+		},
+		"es6-promise": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+			"integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+			"dev": true
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"escodegen": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+			"integrity": "sha1-mBGi8mXcHNOJRCDuNxcGS2MriFI=",
+			"dev": true,
+			"requires": {
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.5.7"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				}
+			}
+		},
+		"esprima": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+			"dev": true
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "0.1.1",
+				"from": "0.1.7",
+				"map-stream": "0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3.3",
+				"stream-combiner": "0.0.4",
+				"through": "2.3.8"
+			}
+		},
+		"event-target-shim": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-1.1.1.tgz",
+			"integrity": "sha1-qG5e5r2qFgVEddp5fM3fDFVphJE="
+		},
+		"eventemitter3": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.0.tgz",
+			"integrity": "sha512-62TxCtz4m2LRaOERVEvLJJ4A6rsg8lC9Xm+FLg2y/1fB/v4ZZ9JCOn+/Ppl5KkH6sRih6bhix724PVanmXYZJQ=="
+		},
+		"exec-sh": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+			"integrity": "sha1-FjuYpuiea2W0fCoo0hW8H2OYnDg=",
+			"requires": {
+				"merge": "1.2.0"
+			}
+		},
+		"execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"requires": {
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"requires": {
+						"lru-cache": "4.1.1",
+						"shebang-command": "1.2.0",
+						"which": "1.3.0"
+					}
+				}
+			}
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"express": {
+			"version": "4.16.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.1.tgz",
+			"integrity": "sha1-azO1YBg8myU7e2IUTfM6RlSsntA=",
+			"requires": {
+				"accepts": "1.3.4",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.2",
+				"content-disposition": "0.5.2",
+				"content-type": "1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "1.1.1",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"finalhandler": "1.1.0",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "2.0.2",
+				"qs": "6.5.1",
+				"range-parser": "1.2.0",
+				"safe-buffer": "5.1.1",
+				"send": "0.16.1",
+				"serve-static": "1.13.1",
+				"setprototypeof": "1.1.0",
+				"statuses": "1.3.1",
+				"type-is": "1.6.15",
+				"utils-merge": "1.0.1",
+				"vary": "1.1.2"
+			}
+		},
+		"express-session": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
+			"integrity": "sha1-XMmPP1/4Ttg1+Ry/CqvQxxB0AK8=",
+			"requires": {
+				"cookie": "0.1.3",
+				"cookie-signature": "1.0.6",
+				"crc": "3.3.0",
+				"debug": "2.2.0",
+				"depd": "1.0.1",
+				"on-headers": "1.0.1",
+				"parseurl": "1.3.2",
+				"uid-safe": "2.0.0",
+				"utils-merge": "1.0.0"
+			},
+			"dependencies": {
+				"cookie": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+					"integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU="
+				},
+				"debug": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+					"requires": {
+						"ms": "0.7.1"
+					}
+				},
+				"depd": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+					"integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+				},
+				"ms": {
+					"version": "0.7.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+				},
+				"uid-safe": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
+					"integrity": "sha1-p/PGymSh9qXQTsDvPkw9U2cxcTc=",
+					"requires": {
+						"base64-url": "1.2.1"
+					}
+				},
+				"utils-merge": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+					"integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+				}
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"external-editor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"requires": {
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.19",
+				"tmp": "0.0.33"
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"requires": {
+				"is-extglob": "1.0.0"
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"fancy-log": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+			"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+			"requires": {
+				"ansi-gray": "0.1.1",
+				"color-support": "1.1.3",
+				"time-stamp": "1.1.0"
+			}
+		},
+		"fast-deep-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"fb-watchman": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"requires": {
+				"bser": "2.0.0"
+			},
+			"dependencies": {
+				"bser": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+					"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+					"requires": {
+						"node-int64": "0.4.0"
+					}
+				}
+			}
+		},
+		"fbjs": {
+			"version": "0.8.16",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.14"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				}
+			}
+		},
+		"fbjs-scripts": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-0.8.1.tgz",
+			"integrity": "sha512-hTjqlua9YJupF8shbVRTq20xKPITnDmqBLBQyR9BttZYT+gxGeKboIzPC19T3Erp29Q0+jdMwjUiyTHR61q1Bw==",
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-preset-fbjs": "2.1.4",
+				"core-js": "2.5.3",
+				"cross-spawn": "5.1.0",
+				"gulp-util": "3.0.8",
+				"object-assign": "4.1.1",
+				"semver": "5.4.1",
+				"through2": "2.0.3"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.5.3",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+					"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				}
+			}
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+		},
+		"fileset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2",
+				"minimatch": "3.0.4"
+			}
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"finalhandler": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+			"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"statuses": "1.3.1",
+				"unpipe": "1.0.0"
+			}
+		},
+		"find-up": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"dev": true,
+			"requires": {
+				"path-exists": "2.1.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.5",
+				"mime-types": "2.1.17"
+			}
+		},
+		"forwarded": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
+		},
+		"fs-extra": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+			"integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"jsonfile": "2.4.0",
+				"klaw": "1.3.1"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fsevents": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+			"integrity": "sha1-MoK3E/s62A7eDp/PRhG1qm/AM/Q=",
+			"optional": true,
+			"requires": {
+				"nan": "2.7.0",
+				"node-pre-gyp": "0.6.36"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+					"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+					"optional": true
+				},
+				"ajv": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+					"optional": true,
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"aproba": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+					"integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+					"optional": true,
+					"requires": {
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
+					}
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+					"optional": true
+				},
+				"assert-plus": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+					"optional": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+					"optional": true
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+					"optional": true
+				},
+				"aws4": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+					"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+					"optional": true
+				},
+				"balanced-match": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+					"optional": true,
+					"requires": {
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"block-stream": {
+					"version": "0.0.9",
+					"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"boom": {
+					"version": "2.10.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+					"requires": {
+						"balanced-match": "0.4.2",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-shims": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+					"optional": true
+				},
+				"co": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+				},
+				"combined-stream": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+					"requires": {
+						"delayed-stream": "1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+				},
+				"cryptiles": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+					"optional": true,
+					"requires": {
+						"boom": "2.10.1"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+							"optional": true
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+					"optional": true
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+					"optional": true
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+					"optional": true
+				},
+				"extsprintf": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+					"optional": true
+				},
+				"form-data": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+					"optional": true,
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+				},
+				"fstream": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
+					}
+				},
+				"fstream-ignore": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+					"optional": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
+					}
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+					"optional": true,
+					"requires": {
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+							"optional": true
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+				},
+				"har-schema": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+					"optional": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+					"optional": true,
+					"requires": {
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+					"optional": true
+				},
+				"hawk": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+					"optional": true,
+					"requires": {
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
+					}
+				},
+				"hoek": {
+					"version": "2.16.3",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+				},
+				"http-signature": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+					"optional": true,
+					"requires": {
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				},
+				"ini": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+					"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+					"optional": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+					"optional": true
+				},
+				"jodid25519": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+					"optional": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+					"optional": true
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+					"optional": true,
+					"requires": {
+						"jsonify": "0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+					"optional": true
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+					"optional": true
+				},
+				"jsprim": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+					"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.0.2",
+						"json-schema": "0.2.3",
+						"verror": "1.3.6"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+							"optional": true
+						}
+					}
+				},
+				"mime-db": {
+					"version": "1.27.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+				},
+				"mime-types": {
+					"version": "2.1.15",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+					"requires": {
+						"mime-db": "1.27.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"requires": {
+						"brace-expansion": "1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"optional": true
+				},
+				"node-pre-gyp": {
+					"version": "0.6.36",
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+					"integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+					"optional": true,
+					"requires": {
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+					"optional": true,
+					"requires": {
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+					"integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+					"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+					"optional": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+				},
+				"performance-now": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"optional": true
+				},
+				"qs": {
+					"version": "6.4.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+					"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+					"optional": true,
+					"requires": {
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.2.9",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+					"requires": {
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.81.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+					"optional": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+				},
+				"semver": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"optional": true
+				},
+				"sntp": {
+					"version": "1.0.9",
+					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+					"optional": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"sshpk": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+					"integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+					"optional": true,
+					"requires": {
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+							"optional": true
+						}
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+					"optional": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"optional": true
+				},
+				"tar": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+					"requires": {
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
+					}
+				},
+				"tar-pack": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+					"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+					"optional": true,
+					"requires": {
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+					"optional": true,
+					"requires": {
+						"punycode": "1.4.1"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+					"optional": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+					"optional": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+					"optional": true
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+					"optional": true
+				},
+				"verror": {
+					"version": "1.3.6",
+					"resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+					"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+					"optional": true,
+					"requires": {
+						"extsprintf": "1.0.2"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+					"optional": true,
+					"requires": {
+						"string-width": "1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+				}
+			}
+		},
+		"gauge": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+			"integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+			"requires": {
+				"ansi": "0.3.1",
+				"has-unicode": "2.0.1",
+				"lodash.pad": "4.5.1",
+				"lodash.padend": "4.6.1",
+				"lodash.padstart": "4.6.1"
+			}
+		},
+		"get-caller-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			}
+		},
+		"glob-parent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"requires": {
+				"is-glob": "2.0.1"
+			}
+		},
+		"global": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+			"requires": {
+				"min-document": "2.19.0",
+				"process": "0.5.2"
+			}
+		},
+		"globals": {
+			"version": "9.18.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+			"integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
+		},
+		"glogg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"got": {
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+			"dev": true,
+			"requires": {
+				"create-error-class": "3.0.2",
+				"duplexer3": "0.1.4",
+				"get-stream": "3.0.0",
+				"is-redirect": "1.0.0",
+				"is-retry-allowed": "1.1.0",
+				"is-stream": "1.1.0",
+				"lowercase-keys": "1.0.0",
+				"safe-buffer": "5.1.1",
+				"timed-out": "4.0.1",
+				"unzip-response": "2.0.1",
+				"url-parse-lax": "1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+		},
+		"gulp-util": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-uniq": "1.0.3",
+				"beeper": "1.1.1",
+				"chalk": "1.1.3",
+				"dateformat": "2.2.0",
+				"fancy-log": "1.3.2",
+				"gulplog": "1.0.0",
+				"has-gulplog": "0.1.0",
+				"lodash._reescape": "3.0.0",
+				"lodash._reevaluate": "3.0.0",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.template": "3.6.2",
+				"minimist": "1.2.0",
+				"multipipe": "0.1.2",
+				"object-assign": "3.0.0",
+				"replace-ext": "0.0.1",
+				"through2": "2.0.3",
+				"vinyl": "0.5.3"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"gulplog": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+			"requires": {
+				"glogg": "1.0.1"
+			}
+		},
+		"handlebars": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+			"integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+			"dev": true,
+			"requires": {
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.7.5"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				}
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+		},
+		"har-validator": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"requires": {
+				"ajv": "5.2.3",
+				"har-schema": "2.0.0"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+			"dev": true
+		},
+		"has-gulplog": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+		},
+		"hawk": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+			"integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+			"requires": {
+				"boom": "4.3.1",
+				"cryptiles": "3.1.2",
+				"hoek": "4.2.0",
+				"sntp": "2.0.2"
+			},
+			"dependencies": {
+				"hoek": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+					"integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+				}
+			}
+		},
+		"home-or-tmp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"requires": {
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+			"integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw="
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
+			"integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
+			"dev": true,
+			"requires": {
+				"whatwg-encoding": "1.0.1"
+			}
+		},
+		"http-errors": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+			"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+			"requires": {
+				"depd": "1.1.1",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.0.3",
+				"statuses": "1.3.1"
+			},
+			"dependencies": {
+				"setprototypeof": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+				}
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
+		},
+		"ignore-by-default": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+			"dev": true
+		},
+		"image-size": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.2.tgz",
+			"integrity": "sha512-pH3vDzpczdsKHdZ9xxR3O46unSjisgVx0IImay7Zz2EdhRVbCkj+nthx9OuuWEhakx9FAO+fNVGrF0rZ2oMOvw=="
+		},
+		"import-lazy": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+			"dev": true
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"ini": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+			"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+			"dev": true
+		},
+		"inquirer": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"requires": {
+				"ansi-escapes": "3.0.0",
+				"chalk": "2.3.0",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.1.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.4",
+				"mute-stream": "0.0.7",
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+					"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
+					}
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				}
+			}
+		},
+		"invariant": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"ipaddr.js": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+			"integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
+			"requires": {
+				"binary-extensions": "1.10.0"
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"requires": {
+				"builtin-modules": "1.1.1"
+			}
+		},
+		"is-ci": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+			"integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+			"dev": true,
+			"requires": {
+				"ci-info": "1.1.1"
+			}
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+		},
+		"is-extglob": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-fullwidth-code-point": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-glob": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"requires": {
+				"is-extglob": "1.0.0"
+			}
+		},
+		"is-npm": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+			"dev": true
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+		},
+		"is-redirect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+			"dev": true
+		},
+		"is-retry-allowed": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+			"dev": true
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"requires": {
+				"isarray": "1.0.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				}
+			}
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"istanbul-api": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.14.tgz",
+			"integrity": "sha1-JbxXAffGgMD//5E95G42GaOm5oA=",
+			"dev": true,
+			"requires": {
+				"async": "2.5.0",
+				"fileset": "2.0.3",
+				"istanbul-lib-coverage": "1.1.1",
+				"istanbul-lib-hook": "1.0.7",
+				"istanbul-lib-instrument": "1.8.0",
+				"istanbul-lib-report": "1.1.1",
+				"istanbul-lib-source-maps": "1.2.1",
+				"istanbul-reports": "1.1.2",
+				"js-yaml": "3.10.0",
+				"mkdirp": "0.5.1",
+				"once": "1.4.0"
+			}
+		},
+		"istanbul-lib-coverage": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+			"integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
+			"dev": true
+		},
+		"istanbul-lib-hook": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
+			"integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
+			"dev": true,
+			"requires": {
+				"append-transform": "0.4.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz",
+			"integrity": "sha1-ZvbJQhzJ7EcE928tsIS6kHiitTI=",
+			"dev": true,
+			"requires": {
+				"babel-generator": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"istanbul-lib-coverage": "1.1.1",
+				"semver": "5.4.1"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+			"integrity": "sha1-8OVfVmVf+jQiIIC3oM1HYOFAX8k=",
+			"dev": true,
+			"requires": {
+				"istanbul-lib-coverage": "1.1.1",
+				"mkdirp": "0.5.1",
+				"path-parse": "1.0.5",
+				"supports-color": "3.2.3"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+			"integrity": "sha1-pv4ay6jOCO68Y45XLilNJnAIqgw=",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"istanbul-lib-coverage": "1.1.1",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"source-map": "0.5.7"
+			}
+		},
+		"istanbul-reports": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+			"integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
+			"dev": true,
+			"requires": {
+				"handlebars": "4.0.10"
+			}
+		},
+		"jest": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
+			"integrity": "sha1-PdJgwpidba1nix6cxNkZRPbWAqw=",
+			"dev": true,
+			"requires": {
+				"jest-cli": "20.0.4"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"jest-cli": {
+					"version": "20.0.4",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
+					"integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "1.4.0",
+						"callsites": "2.0.0",
+						"chalk": "1.1.3",
+						"graceful-fs": "4.1.11",
+						"is-ci": "1.0.10",
+						"istanbul-api": "1.1.14",
+						"istanbul-lib-coverage": "1.1.1",
+						"istanbul-lib-instrument": "1.8.0",
+						"istanbul-lib-source-maps": "1.2.1",
+						"jest-changed-files": "20.0.3",
+						"jest-config": "20.0.4",
+						"jest-docblock": "20.0.3",
+						"jest-environment-jsdom": "20.0.3",
+						"jest-haste-map": "20.0.5",
+						"jest-jasmine2": "20.0.4",
+						"jest-message-util": "20.0.3",
+						"jest-regex-util": "20.0.3",
+						"jest-resolve-dependencies": "20.0.3",
+						"jest-runtime": "20.0.4",
+						"jest-snapshot": "20.0.3",
+						"jest-util": "20.0.3",
+						"micromatch": "2.3.11",
+						"node-notifier": "5.1.2",
+						"pify": "2.3.0",
+						"slash": "1.0.0",
+						"string-length": "1.0.1",
+						"throat": "3.2.0",
+						"which": "1.3.0",
+						"worker-farm": "1.5.0",
+						"yargs": "7.1.0"
+					}
+				},
+				"yargs": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+					"dev": true,
+					"requires": {
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "5.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+					"dev": true,
+					"requires": {
+						"camelcase": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
+			"integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g=",
+			"dev": true
+		},
+		"jest-config": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
+			"integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"glob": "7.1.2",
+				"jest-environment-jsdom": "20.0.3",
+				"jest-environment-node": "20.0.3",
+				"jest-jasmine2": "20.0.4",
+				"jest-matcher-utils": "20.0.3",
+				"jest-regex-util": "20.0.3",
+				"jest-resolve": "20.0.4",
+				"jest-validate": "20.0.3",
+				"pretty-format": "20.0.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "20.0.3",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
+					"integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1",
+						"ansi-styles": "3.2.0"
+					}
+				}
+			}
+		},
+		"jest-diff": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
+			"integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"diff": "3.3.1",
+				"jest-matcher-utils": "20.0.3",
+				"pretty-format": "20.0.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "20.0.3",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
+					"integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1",
+						"ansi-styles": "3.2.0"
+					}
+				}
+			}
+		},
+		"jest-docblock": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
+			"integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI=",
+			"dev": true
+		},
+		"jest-environment-jsdom": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
+			"integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
+			"dev": true,
+			"requires": {
+				"jest-mock": "20.0.3",
+				"jest-util": "20.0.3",
+				"jsdom": "9.12.0"
+			}
+		},
+		"jest-environment-node": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
+			"integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
+			"dev": true,
+			"requires": {
+				"jest-mock": "20.0.3",
+				"jest-util": "20.0.3"
+			}
+		},
+		"jest-haste-map": {
+			"version": "20.0.5",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.5.tgz",
+			"integrity": "sha1-q61077GgBZdKe2UX4RAQcJyrkRI=",
+			"dev": true,
+			"requires": {
+				"fb-watchman": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-docblock": "20.0.3",
+				"micromatch": "2.3.11",
+				"sane": "1.6.0",
+				"worker-farm": "1.5.0"
+			},
+			"dependencies": {
+				"bser": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
+					"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+					"dev": true,
+					"requires": {
+						"node-int64": "0.4.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"sane": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
+					"integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
+					"dev": true,
+					"requires": {
+						"anymatch": "1.3.2",
+						"exec-sh": "0.2.1",
+						"fb-watchman": "1.9.2",
+						"minimatch": "3.0.4",
+						"minimist": "1.2.0",
+						"walker": "1.0.7",
+						"watch": "0.10.0"
+					},
+					"dependencies": {
+						"fb-watchman": {
+							"version": "1.9.2",
+							"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
+							"integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
+							"dev": true,
+							"requires": {
+								"bser": "1.0.2"
+							}
+						}
+					}
+				}
+			}
+		},
+		"jest-jasmine2": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
+			"integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"graceful-fs": "4.1.11",
+				"jest-diff": "20.0.3",
+				"jest-matcher-utils": "20.0.3",
+				"jest-matchers": "20.0.3",
+				"jest-message-util": "20.0.3",
+				"jest-snapshot": "20.0.3",
+				"once": "1.4.0",
+				"p-map": "1.2.0"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
+			"integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"pretty-format": "20.0.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "20.0.3",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
+					"integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1",
+						"ansi-styles": "3.2.0"
+					}
+				}
+			}
+		},
+		"jest-matchers": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
+			"integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
+			"dev": true,
+			"requires": {
+				"jest-diff": "20.0.3",
+				"jest-matcher-utils": "20.0.3",
+				"jest-message-util": "20.0.3",
+				"jest-regex-util": "20.0.3"
+			}
+		},
+		"jest-message-util": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
+			"integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"micromatch": "2.3.11",
+				"slash": "1.0.0"
+			}
+		},
+		"jest-mock": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
+			"integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk=",
+			"dev": true
+		},
+		"jest-regex-util": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
+			"integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I=",
+			"dev": true
+		},
+		"jest-resolve": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
+			"integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
+			"dev": true,
+			"requires": {
+				"browser-resolve": "1.11.2",
+				"is-builtin-module": "1.0.0",
+				"resolve": "1.4.0"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
+			"integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
+			"dev": true,
+			"requires": {
+				"jest-regex-util": "20.0.3"
+			}
+		},
+		"jest-runtime": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
+			"integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
+			"dev": true,
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-jest": "20.0.3",
+				"babel-plugin-istanbul": "4.1.5",
+				"chalk": "1.1.3",
+				"convert-source-map": "1.5.0",
+				"graceful-fs": "4.1.11",
+				"jest-config": "20.0.4",
+				"jest-haste-map": "20.0.5",
+				"jest-regex-util": "20.0.3",
+				"jest-resolve": "20.0.4",
+				"jest-util": "20.0.3",
+				"json-stable-stringify": "1.0.1",
+				"micromatch": "2.3.11",
+				"strip-bom": "3.0.0",
+				"yargs": "7.1.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				},
+				"yargs": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+					"dev": true,
+					"requires": {
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "5.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+					"dev": true,
+					"requires": {
+						"camelcase": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-snapshot": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
+			"integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"jest-diff": "20.0.3",
+				"jest-matcher-utils": "20.0.3",
+				"jest-util": "20.0.3",
+				"natural-compare": "1.4.0",
+				"pretty-format": "20.0.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "20.0.3",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
+					"integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1",
+						"ansi-styles": "3.2.0"
+					}
+				}
+			}
+		},
+		"jest-util": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
+			"integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"graceful-fs": "4.1.11",
+				"jest-message-util": "20.0.3",
+				"jest-mock": "20.0.3",
+				"jest-validate": "20.0.3",
+				"leven": "2.1.0",
+				"mkdirp": "0.5.1"
+			}
+		},
+		"jest-validate": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
+			"integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"jest-matcher-utils": "20.0.3",
+				"leven": "2.1.0",
+				"pretty-format": "20.0.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "20.0.3",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
+					"integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1",
+						"ansi-styles": "3.2.0"
+					}
+				}
+			}
+		},
+		"jest-worker": {
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.1.0.tgz",
+			"integrity": "sha512-ezLueYAQowk5N6g2J7bNZfq4NWZvMNB5Qd24EmOZLcM5SXTdiFvxykZIoNiMj9C98cCbPaojX8tfR7b1LJwNig==",
+			"requires": {
+				"merge-stream": "1.0.1"
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"js-yaml": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+			"integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+			"dev": true,
+			"requires": {
+				"argparse": "1.0.9",
+				"esprima": "4.0.0"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
+		},
+		"jsdom": {
+			"version": "9.12.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
+			"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+			"dev": true,
+			"requires": {
+				"abab": "1.0.4",
+				"acorn": "4.0.13",
+				"acorn-globals": "3.1.0",
+				"array-equal": "1.0.0",
+				"content-type-parser": "1.0.1",
+				"cssom": "0.3.2",
+				"cssstyle": "0.2.37",
+				"escodegen": "1.9.0",
+				"html-encoding-sniffer": "1.0.1",
+				"nwmatcher": "1.4.2",
+				"parse5": "1.5.1",
+				"request": "2.83.0",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.3",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.1",
+				"whatwg-url": "4.8.0",
+				"xml-name-validator": "2.0.1"
+			},
+			"dependencies": {
+				"sax": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+					"integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+					"dev": true
+				}
+			}
+		},
+		"jsesc": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"json5": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+			"integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+		},
+		"jsonfile": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"requires": {
+				"is-buffer": "1.1.5"
+			}
+		},
+		"klaw": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"latest-version": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+			"dev": true,
+			"requires": {
+				"package-json": "4.0.1"
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true,
+			"optional": true
+		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"requires": {
+				"invert-kv": "1.0.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
+		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"dev": true
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"requires": {
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
+			},
+			"dependencies": {
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+				}
+			}
+		},
+		"lodash": {
+			"version": "4.17.4",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+		},
+		"lodash._baseassign": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+			"dev": true,
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash.keys": "3.1.2"
+			}
+		},
+		"lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+		},
+		"lodash._basetostring": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+		},
+		"lodash._basevalues": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+		},
+		"lodash._bindcallback": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+			"dev": true
+		},
+		"lodash._createassigner": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+			"integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+			"dev": true,
+			"requires": {
+				"lodash._bindcallback": "3.0.1",
+				"lodash._isiterateecall": "3.0.9",
+				"lodash.restparam": "3.6.1"
+			}
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+		},
+		"lodash._reescape": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+		},
+		"lodash._reevaluate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+		},
+		"lodash._root": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+		},
+		"lodash.assign": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+			"integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+			"dev": true,
+			"requires": {
+				"lodash._baseassign": "3.2.0",
+				"lodash._createassigner": "3.1.1",
+				"lodash.keys": "3.1.2"
+			}
+		},
+		"lodash.defaults": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+			"integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
+			"dev": true,
+			"requires": {
+				"lodash.assign": "3.2.0",
+				"lodash.restparam": "3.6.1"
+			}
+		},
+		"lodash.escape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+			"requires": {
+				"lodash._root": "3.0.1"
+			}
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"requires": {
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
+			}
+		},
+		"lodash.pad": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+			"integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA="
+		},
+		"lodash.padend": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+			"integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+		},
+		"lodash.padstart": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+			"integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
+		},
+		"lodash.restparam": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+		},
+		"lodash.template": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash._basetostring": "3.0.1",
+				"lodash._basevalues": "3.0.0",
+				"lodash._isiterateecall": "3.0.9",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0",
+				"lodash.keys": "3.1.2",
+				"lodash.restparam": "3.6.1",
+				"lodash.templatesettings": "3.1.1"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+			"requires": {
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0"
+			}
+		},
+		"lodash.throttle": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"lowercase-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+			"dev": true
+		},
+		"lru-cache": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+			"integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			}
+		},
+		"macos-release": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+			"integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
+		},
+		"make-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+			"integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+			"dev": true,
+			"requires": {
+				"pify": "2.3.0"
+			}
+		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"requires": {
+				"tmpl": "1.0.4"
+			}
+		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+		},
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"merge": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
+		"method-override": {
+			"version": "2.3.10",
+			"resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.10.tgz",
+			"integrity": "sha1-49r41d7hDdLc59SuiNYrvud0drQ=",
+			"requires": {
+				"debug": "2.6.9",
+				"methods": "1.1.2",
+				"parseurl": "1.3.2",
+				"vary": "1.1.2"
+			}
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+		},
+		"metro": {
+			"version": "0.24.7",
+			"resolved": "https://registry.npmjs.org/metro/-/metro-0.24.7.tgz",
+			"integrity": "sha512-9Fr3PDPPCTR3WJUHPLZL2nvyEWyvqyyxH9649OmA2TOF7VEtRzWedZlc6PAcl/rDOzwDOu2/c98NRFxnS1CYlw==",
+			"requires": {
+				"absolute-path": "0.0.0",
+				"async": "2.5.0",
+				"babel-core": "6.26.0",
+				"babel-generator": "6.26.0",
+				"babel-plugin-external-helpers": "6.22.0",
+				"babel-preset-es2015-node": "6.1.1",
+				"babel-preset-fbjs": "2.1.4",
+				"babel-preset-react-native": "4.0.0",
+				"babel-register": "6.26.0",
+				"babylon": "6.18.0",
+				"chalk": "1.1.3",
+				"concat-stream": "1.6.0",
+				"connect": "3.6.5",
+				"core-js": "2.5.3",
+				"debug": "2.6.9",
+				"denodeify": "1.2.1",
+				"eventemitter3": "3.0.0",
+				"fbjs": "0.8.16",
+				"fs-extra": "1.0.0",
+				"graceful-fs": "4.1.11",
+				"image-size": "0.6.2",
+				"jest-docblock": "22.1.0",
+				"jest-haste-map": "22.1.0",
+				"jest-worker": "22.1.0",
+				"json-stable-stringify": "1.0.1",
+				"json5": "0.4.0",
+				"left-pad": "1.2.0",
+				"lodash.throttle": "4.1.1",
+				"merge-stream": "1.0.1",
+				"metro-core": "0.24.7",
+				"metro-source-map": "0.24.7",
+				"mime-types": "2.1.11",
+				"mkdirp": "0.5.1",
+				"request": "2.83.0",
+				"rimraf": "2.6.2",
+				"serialize-error": "2.1.0",
+				"source-map": "0.5.7",
+				"temp": "0.8.3",
+				"throat": "4.1.0",
+				"uglify-es": "3.3.9",
+				"wordwrap": "1.0.0",
+				"write-file-atomic": "1.3.4",
+				"ws": "1.1.5",
+				"xpipe": "1.0.5",
+				"yargs": "9.0.1"
+			},
+			"dependencies": {
+				"babel-plugin-react-transform": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-3.0.0.tgz",
+					"integrity": "sha512-4vJGddwPiHAOgshzZdGwYy4zRjjIr5SMY7gkOaCyIASjgpcsyLTlZNuB5rHOFoaTvGlhfo8/g4pobXPyHqm/3w==",
+					"requires": {
+						"lodash": "4.17.4"
+					}
+				},
+				"babel-preset-react-native": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-4.0.0.tgz",
+					"integrity": "sha512-Wfbo6x244nUbBxjr7hQaNFdjj7FDYU+TVT7cFVPEdVPI68vhN52iLvamm+ErhNdHq6M4j1cMT6AJBYx7Wzdr0g==",
+					"requires": {
+						"babel-plugin-check-es2015-constants": "6.22.0",
+						"babel-plugin-react-transform": "3.0.0",
+						"babel-plugin-syntax-async-functions": "6.13.0",
+						"babel-plugin-syntax-class-properties": "6.13.0",
+						"babel-plugin-syntax-dynamic-import": "6.18.0",
+						"babel-plugin-syntax-flow": "6.18.0",
+						"babel-plugin-syntax-jsx": "6.18.0",
+						"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+						"babel-plugin-transform-class-properties": "6.24.1",
+						"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+						"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+						"babel-plugin-transform-es2015-classes": "6.24.1",
+						"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+						"babel-plugin-transform-es2015-destructuring": "6.23.0",
+						"babel-plugin-transform-es2015-for-of": "6.23.0",
+						"babel-plugin-transform-es2015-function-name": "6.24.1",
+						"babel-plugin-transform-es2015-literals": "6.22.0",
+						"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+						"babel-plugin-transform-es2015-parameters": "6.24.1",
+						"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+						"babel-plugin-transform-es2015-spread": "6.22.0",
+						"babel-plugin-transform-es2015-template-literals": "6.22.0",
+						"babel-plugin-transform-flow-strip-types": "6.22.0",
+						"babel-plugin-transform-object-assign": "6.22.0",
+						"babel-plugin-transform-object-rest-spread": "6.26.0",
+						"babel-plugin-transform-react-display-name": "6.25.0",
+						"babel-plugin-transform-react-jsx": "6.24.1",
+						"babel-plugin-transform-react-jsx-source": "6.22.0",
+						"babel-plugin-transform-regenerator": "6.26.0",
+						"babel-template": "6.26.0",
+						"react-transform-hmr": "1.0.4"
+					}
+				},
+				"connect": {
+					"version": "3.6.5",
+					"resolved": "https://registry.npmjs.org/connect/-/connect-3.6.5.tgz",
+					"integrity": "sha1-+43ee6B2OHfQ7J352sC0tA5yx9o=",
+					"requires": {
+						"debug": "2.6.9",
+						"finalhandler": "1.0.6",
+						"parseurl": "1.3.2",
+						"utils-merge": "1.0.1"
+					}
+				},
+				"core-js": {
+					"version": "2.5.3",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+					"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+				},
+				"finalhandler": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
+					"integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+					"requires": {
+						"debug": "2.6.9",
+						"encodeurl": "1.0.1",
+						"escape-html": "1.0.3",
+						"on-finished": "2.3.0",
+						"parseurl": "1.3.2",
+						"statuses": "1.3.1",
+						"unpipe": "1.0.0"
+					}
+				},
+				"jest-docblock": {
+					"version": "22.1.0",
+					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.1.0.tgz",
+					"integrity": "sha512-/+OGgBVRJb5wCbXrB1LQvibQBz2SdrvDdKRNzY1gL+OISQJZCR9MOewbygdT5rVzbbkfhC4AR2x+qWmNUdJfjw==",
+					"requires": {
+						"detect-newline": "2.1.0"
+					}
+				},
+				"jest-haste-map": {
+					"version": "22.1.0",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.1.0.tgz",
+					"integrity": "sha512-vETdC6GboGlZX6+9SMZkXtYRQSKBbQ47sFF7NGglbMN4eyIZBODply8rlcO01KwBiAeiNCKdjUyfonZzJ93JEg==",
+					"requires": {
+						"fb-watchman": "2.0.0",
+						"graceful-fs": "4.1.11",
+						"jest-docblock": "22.1.0",
+						"jest-worker": "22.1.0",
+						"micromatch": "2.3.11",
+						"sane": "2.3.0"
+					}
+				},
+				"mime-db": {
+					"version": "1.23.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+					"integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+				},
+				"mime-types": {
+					"version": "2.1.11",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+					"integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+					"requires": {
+						"mime-db": "1.23.0"
+					}
+				},
+				"throat": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+					"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+				},
+				"uglify-es": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+					"requires": {
+						"commander": "2.13.0",
+						"source-map": "0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+						}
+					}
+				}
+			}
+		},
+		"metro-core": {
+			"version": "0.24.7",
+			"resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.24.7.tgz",
+			"integrity": "sha512-Qheab9Wmc8T2m3Ax9COyKUk8LxRb1fHWe13CpoEgPIjwFBd6ILNXaq7ZzoWg0OoAbpMsNzvUOnOJNHvfRuJqJg==",
+			"requires": {
+				"lodash.throttle": "4.1.1"
+			}
+		},
+		"metro-source-map": {
+			"version": "0.24.7",
+			"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.24.7.tgz",
+			"integrity": "sha512-12WEgolY5CGvHeHkF5QlM2qatdQC1DyjWkXLK9LzCqzd8YhUZww1+ZCM6E67rJwpeuCU9o1Mkiwd1h7dS+RBvA==",
+			"requires": {
+				"source-map": "0.5.7"
+			}
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
+			}
+		},
+		"mime": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+			"integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
+		},
+		"mime-db": {
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+		},
+		"mime-types": {
+			"version": "2.1.17",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"requires": {
+				"mime-db": "1.30.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"min-document": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+			"requires": {
+				"dom-walk": "0.1.1"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+			"requires": {
+				"brace-expansion": "1.1.8"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"morgan": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
+			"integrity": "sha1-X9gYOYxoGcuiinzWZk8pL+HAu/I=",
+			"requires": {
+				"basic-auth": "1.0.4",
+				"debug": "2.2.0",
+				"depd": "1.0.1",
+				"on-finished": "2.3.0",
+				"on-headers": "1.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+					"requires": {
+						"ms": "0.7.1"
+					}
+				},
+				"depd": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+					"integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+				},
+				"ms": {
+					"version": "0.7.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+				}
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"multer": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/multer/-/multer-1.3.0.tgz",
+			"integrity": "sha1-CSsmcPaEb6SRSWXvyM+Uwg/sbNI=",
+			"requires": {
+				"append-field": "0.1.0",
+				"busboy": "0.2.14",
+				"concat-stream": "1.6.0",
+				"mkdirp": "0.5.1",
+				"object-assign": "3.0.0",
+				"on-finished": "2.3.0",
+				"type-is": "1.6.15",
+				"xtend": "4.0.1"
+			}
+		},
+		"multiparty": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
+			"integrity": "sha1-Nd5oBNwZZD5SSfPT473GyM4wHT8=",
+			"requires": {
+				"readable-stream": "1.1.14",
+				"stream-counter": "0.2.0"
+			}
+		},
+		"multipipe": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+			"requires": {
+				"duplexer2": "0.0.2"
+			}
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+		},
+		"nan": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+			"optional": true
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"negotiator": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+		},
+		"node-notifier": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
+			"integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+			"requires": {
+				"growly": "1.3.0",
+				"semver": "5.4.1",
+				"shellwords": "0.1.1",
+				"which": "1.3.0"
+			}
+		},
+		"nodemon": {
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.12.1.tgz",
+			"integrity": "sha1-mWpW3EnZ8Wu/G3ik3gjxNjSzh40=",
+			"dev": true,
+			"requires": {
+				"chokidar": "1.7.0",
+				"debug": "2.6.9",
+				"es6-promise": "3.3.1",
+				"ignore-by-default": "1.0.1",
+				"lodash.defaults": "3.1.2",
+				"minimatch": "3.0.4",
+				"ps-tree": "1.1.0",
+				"touch": "3.1.0",
+				"undefsafe": "0.0.3",
+				"update-notifier": "2.2.0"
+			}
+		},
+		"nopt": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+			"integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1.1.1"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+			"requires": {
+				"hosted-git-info": "2.5.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.4.1",
+				"validate-npm-package-license": "3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"requires": {
+				"remove-trailing-separator": "1.1.0"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"requires": {
+				"path-key": "2.0.1"
+			}
+		},
+		"npmlog": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+			"integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
+			"requires": {
+				"ansi": "0.3.1",
+				"are-we-there-yet": "1.1.4",
+				"gauge": "1.2.7"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"nwmatcher": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.2.tgz",
+			"integrity": "sha1-xeVFq0DSKlawMmUxxL6u16iIs+o=",
+			"dev": true
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"object-assign": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+			"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
+		"on-headers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"opn": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+			"integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
+			"requires": {
+				"object-assign": "4.1.1"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				}
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"requires": {
+				"minimist": "0.0.8",
+				"wordwrap": "0.0.3"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+				}
+			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			}
+		},
+		"options": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+			"integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+		},
+		"os-locale": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"dev": true,
+			"requires": {
+				"lcid": "1.0.0"
+			}
+		},
+		"os-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+			"integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+			"requires": {
+				"macos-release": "1.1.0",
+				"win-release": "1.1.1"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-limit": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"requires": {
+				"p-limit": "1.1.0"
+			}
+		},
+		"p-map": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+			"integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
+			"dev": true
+		},
+		"package-json": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+			"dev": true,
+			"requires": {
+				"got": "6.7.1",
+				"registry-auth-token": "3.3.1",
+				"registry-url": "3.1.0",
+				"semver": "5.4.1"
+			}
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"requires": {
+				"error-ex": "1.3.1"
+			}
+		},
+		"parse5": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+			"dev": true
+		},
+		"parseurl": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+		},
+		"path-exists": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+			"dev": true,
+			"requires": {
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-parse": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
+		},
+		"path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+		},
+		"path-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"pause": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
+			"integrity": "sha1-68ikqGGf8LioGsFRPDQ0/0af23Q="
+		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
+		"pegjs": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+			"integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
+			"requires": {
+				"pinkie": "2.0.4"
+			}
+		},
+		"plist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
+			"integrity": "sha1-CEtQk93JJQbiWfh0uNmxr7jHlZM=",
+			"requires": {
+				"base64-js": "0.0.8",
+				"util-deprecate": "1.0.2",
+				"xmlbuilder": "4.0.0",
+				"xmldom": "0.1.27"
+			},
+			"dependencies": {
+				"base64-js": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+					"integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+				}
+			}
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+			"dev": true
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+		},
+		"pretty-format": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
+			"integrity": "sha1-UwvlxCs8BbNkFKeipDN6qArNDo0="
+		},
+		"private": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+		},
+		"process": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+		},
+		"process-nextick-args": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"prop-types": {
+			"version": "15.6.0",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+			"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				}
+			}
+		},
+		"proxy-addr": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+			"integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+			"requires": {
+				"forwarded": "0.1.2",
+				"ipaddr.js": "1.5.2"
+			}
+		},
+		"prr": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+			"dev": true
+		},
+		"ps-tree": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+			"dev": true,
+			"requires": {
+				"event-stream": "3.3.4"
+			}
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
+		},
+		"random-bytes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+			"integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "1.1.5"
+					}
+				}
+			}
+		},
+		"range-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+		},
+		"raw-body": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+			"requires": {
+				"bytes": "3.0.0",
+				"http-errors": "1.6.2",
+				"iconv-lite": "0.4.19",
+				"unpipe": "1.0.0"
+			}
+		},
+		"rc": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+			"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+			"dev": true,
+			"requires": {
+				"deep-extend": "0.4.2",
+				"ini": "1.3.4",
+				"minimist": "1.2.0",
+				"strip-json-comments": "2.0.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
+		"react": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+			"integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.0"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				}
+			}
+		},
+		"react-clone-referenced-element": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.0.1.tgz",
+			"integrity": "sha1-K7qMaUBMXkqUQ5hgC8xMlB+GBoI="
+		},
+		"react-deep-force-update": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz",
+			"integrity": "sha1-vNMUeAJ7ZLMznxCJIatSC0MT3Cw="
+		},
+		"react-devtools-core": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.0.0.tgz",
+			"integrity": "sha512-24oLTwNqZJceQXfAfKRp3PwCyg2agXAQhgGwe/x6V6CvjLmnMmba4/ut9S8JTIJq7pS9fpPaRDGo5u3923RLFA==",
+			"requires": {
+				"shell-quote": "1.6.1",
+				"ws": "2.3.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+				},
+				"ultron": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+					"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+				},
+				"ws": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
+					"integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+					"requires": {
+						"safe-buffer": "5.0.1",
+						"ultron": "1.1.1"
+					}
+				}
+			}
+		},
+		"react-native": {
+			"version": "0.52.2",
+			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.52.2.tgz",
+			"integrity": "sha512-qOYONkFlDgexHjZaAf0LNnP2/AXv4I0YQY55KQFD64IkuEsG2DVWE8e25KjMs0zBRDTZBVP35b2zb6OM+OfHCg==",
+			"requires": {
+				"absolute-path": "0.0.0",
+				"art": "0.10.1",
+				"babel-core": "6.26.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-to-generator": "6.16.0",
+				"babel-plugin-transform-class-properties": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"babel-plugin-transform-flow-strip-types": "6.22.0",
+				"babel-plugin-transform-object-rest-spread": "6.26.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"base64-js": "1.2.1",
+				"chalk": "1.1.3",
+				"commander": "2.13.0",
+				"connect": "2.30.2",
+				"create-react-class": "15.6.2",
+				"debug": "2.6.9",
+				"denodeify": "1.2.1",
+				"envinfo": "3.11.1",
+				"event-target-shim": "1.1.1",
+				"fbjs": "0.8.16",
+				"fbjs-scripts": "0.8.1",
+				"fs-extra": "1.0.0",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"inquirer": "3.3.0",
+				"lodash": "4.17.4",
+				"metro": "0.24.7",
+				"metro-core": "0.24.7",
+				"mime": "1.4.1",
+				"minimist": "1.2.0",
+				"mkdirp": "0.5.1",
+				"node-fetch": "1.7.3",
+				"node-notifier": "5.1.2",
+				"npmlog": "2.0.4",
+				"opn": "3.0.3",
+				"optimist": "0.6.1",
+				"plist": "1.2.0",
+				"pretty-format": "4.3.1",
+				"promise": "7.3.1",
+				"prop-types": "15.6.0",
+				"react-clone-referenced-element": "1.0.1",
+				"react-devtools-core": "3.0.0",
+				"react-timer-mixin": "0.13.3",
+				"regenerator-runtime": "0.11.1",
+				"rimraf": "2.6.2",
+				"semver": "5.4.1",
+				"shell-quote": "1.6.1",
+				"stacktrace-parser": "0.1.4",
+				"whatwg-fetch": "1.1.1",
+				"ws": "1.1.5",
+				"xcode": "0.9.3",
+				"xmldoc": "0.4.0",
+				"yargs": "9.0.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"whatwg-fetch": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz",
+					"integrity": "sha1-rDydOfMgxtzlM5lp0FTvQ90zMxk="
+				}
+			}
+		},
+		"react-native-background-upload": {
+			"version": "file:../react-native-background-upload"
+		},
+		"react-native-image-picker": {
+			"version": "0.26.7",
+			"resolved": "https://registry.npmjs.org/react-native-image-picker/-/react-native-image-picker-0.26.7.tgz",
+			"integrity": "sha1-rS7pV/f2zAE5aJPqA9hMsq2y43Y="
+		},
+		"react-proxy": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
+			"integrity": "sha1-nb/Z2SdSjDqp9ETkVYw3gwq4wmo=",
+			"requires": {
+				"lodash": "4.17.4",
+				"react-deep-force-update": "1.1.1"
+			}
+		},
+		"react-test-renderer": {
+			"version": "16.0.0-alpha.12",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.0.0-alpha.12.tgz",
+			"integrity": "sha1-nkzF2M6L/KcneDQN4+FFS51sDMU=",
+			"dev": true,
+			"requires": {
+				"fbjs": "0.8.16",
+				"object-assign": "4.1.1"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"dev": true
+				}
+			}
+		},
+		"react-timer-mixin": {
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.3.tgz",
+			"integrity": "sha1-Dai5+AfsB9w+hU0ILHN8ZWBbPSI="
+		},
+		"react-transform-hmr": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz",
+			"integrity": "sha1-4aQL0Krvxy6N/Xp82gmvhQZjl7s=",
+			"requires": {
+				"global": "4.3.2",
+				"react-proxy": "1.1.8"
+			}
+		},
+		"read-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"dev": true,
+			"requires": {
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"dev": true,
+			"requires": {
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
+			}
+		},
+		"readable-stream": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+			"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "0.0.1",
+				"string_decoder": "0.10.31"
+			}
+		},
+		"readdirp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.3",
+				"set-immediate-shim": "1.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
+		"regenerate": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+			"integrity": "sha1-DDNtOYBVPXVcObWGrjsgqknIK38="
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+		},
+		"regenerator-transform": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+			"integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"private": "0.1.7"
+			}
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+			"requires": {
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"regexpu-core": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"requires": {
+				"regenerate": "1.3.3",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
+			}
+		},
+		"registry-auth-token": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+			"integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+			"dev": true,
+			"requires": {
+				"rc": "1.2.1",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"registry-url": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"dev": true,
+			"requires": {
+				"rc": "1.2.1"
+			}
+		},
+		"regjsgen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+		},
+		"regjsparser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"requires": {
+				"jsesc": "0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				}
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"requires": {
+				"is-finite": "1.0.2"
+			}
+		},
+		"replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+		},
+		"request": {
+			"version": "2.83.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+			"integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
+			"requires": {
+				"aws-sign2": "0.7.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.5",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.1",
+				"har-validator": "5.0.3",
+				"hawk": "6.0.2",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.17",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.1",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.3",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.1.0"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+		},
+		"resolve": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+			"integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
+			"dev": true,
+			"requires": {
+				"path-parse": "1.0.5"
+			}
+		},
+		"response-time": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
+			"integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
+			"requires": {
+				"depd": "1.1.1",
+				"on-headers": "1.0.1"
+			}
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"requires": {
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"rimraf": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+			"integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+			"requires": {
+				"glob": "7.1.2"
+			}
+		},
+		"rndm": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+			"integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
+		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"requires": {
+				"is-promise": "2.1.0"
+			}
+		},
+		"rx-lite": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+		},
+		"rx-lite-aggregates": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"requires": {
+				"rx-lite": "4.0.8"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+		},
+		"sane": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-2.3.0.tgz",
+			"integrity": "sha512-6GB9zPCsqJqQPAGcvEkUPijM1ZUFI+A/DrscL++dXO3Ltt5q5mPDayGxZtr3cBRkrbb4akbwszVVkTIFefEkcg==",
+			"requires": {
+				"anymatch": "1.3.2",
+				"exec-sh": "0.2.1",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.1.2",
+				"minimatch": "3.0.4",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.18.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"watch": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+					"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+					"requires": {
+						"exec-sh": "0.2.1",
+						"minimist": "1.2.0"
+					}
+				}
+			}
+		},
+		"sax": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
+			"integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
+		},
+		"semver": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+			"integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+		},
+		"semver-diff": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"dev": true,
+			"requires": {
+				"semver": "5.4.1"
+			}
+		},
+		"send": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+			"integrity": "sha1-pw4coh0TgsEdDZ9iMd6ygQgNerM=",
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "1.1.1",
+				"destroy": "1.0.4",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "1.6.2",
+				"mime": "1.4.1",
+				"ms": "2.0.0",
+				"on-finished": "2.3.0",
+				"range-parser": "1.2.0",
+				"statuses": "1.3.1"
+			}
+		},
+		"serialize-error": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+			"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
+		},
+		"serve-favicon": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz",
+			"integrity": "sha1-3UGeJo3gEqtysxnTN/IQUBP5OB8=",
+			"requires": {
+				"etag": "1.7.0",
+				"fresh": "0.3.0",
+				"ms": "0.7.2",
+				"parseurl": "1.3.2"
+			},
+			"dependencies": {
+				"etag": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+					"integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+				},
+				"fresh": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+					"integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+				},
+				"ms": {
+					"version": "0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+				}
+			}
+		},
+		"serve-index": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
+			"integrity": "sha1-egV/xu4o3GP2RWbl+lexEahq7NI=",
+			"requires": {
+				"accepts": "1.2.13",
+				"batch": "0.5.3",
+				"debug": "2.2.0",
+				"escape-html": "1.0.3",
+				"http-errors": "1.3.1",
+				"mime-types": "2.1.17",
+				"parseurl": "1.3.2"
+			},
+			"dependencies": {
+				"accepts": {
+					"version": "1.2.13",
+					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+					"integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+					"requires": {
+						"mime-types": "2.1.17",
+						"negotiator": "0.5.3"
+					}
+				},
+				"debug": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+					"requires": {
+						"ms": "0.7.1"
+					}
+				},
+				"http-errors": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+					"integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+					"requires": {
+						"inherits": "2.0.3",
+						"statuses": "1.3.1"
+					}
+				},
+				"ms": {
+					"version": "0.7.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+				},
+				"negotiator": {
+					"version": "0.5.3",
+					"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+					"integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
+				}
+			}
+		},
+		"serve-static": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+			"integrity": "sha1-TFfVNASnYdjy58HooYpH2/J4pxk=",
+			"requires": {
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"parseurl": "1.3.2",
+				"send": "0.16.1"
+			}
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"set-immediate-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"setprototypeof": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"requires": {
+				"shebang-regex": "1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"shell-quote": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+			"requires": {
+				"array-filter": "0.0.1",
+				"array-map": "0.0.0",
+				"array-reduce": "0.0.0",
+				"jsonify": "0.0.0"
+			}
+		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs="
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"simple-plist": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.2.1.tgz",
+			"integrity": "sha1-cXZts1IyaSjPOoByQrp2IyJjZyM=",
+			"requires": {
+				"bplist-creator": "0.0.7",
+				"bplist-parser": "0.1.1",
+				"plist": "2.0.1"
+			},
+			"dependencies": {
+				"base64-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz",
+					"integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg="
+				},
+				"plist": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz",
+					"integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os=",
+					"requires": {
+						"base64-js": "1.1.2",
+						"xmlbuilder": "8.2.2",
+						"xmldom": "0.1.27"
+					}
+				},
+				"xmlbuilder": {
+					"version": "8.2.2",
+					"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+					"integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
+				}
+			}
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+		},
+		"slide": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+		},
+		"sntp": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+			"integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+			"requires": {
+				"hoek": "4.2.0"
+			},
+			"dependencies": {
+				"hoek": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+					"integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"source-map-support": {
+			"version": "0.4.18",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+			"integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
+			"requires": {
+				"source-map": "0.5.7"
+			}
+		},
+		"sparkles": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+		},
+		"spdx-correct": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"requires": {
+				"spdx-license-ids": "1.2.2"
+			}
+		},
+		"spdx-expression-parse": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+		},
+		"spdx-license-ids": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"stacktrace-parser": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.4.tgz",
+			"integrity": "sha1-ATl5IuX2Ls8whFUiyVxP4dJefU4="
+		},
+		"statuses": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+			"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+		},
+		"stream-buffers": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+			"integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
+		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "0.1.1"
+			}
+		},
+		"stream-counter": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+			"integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
+			"requires": {
+				"readable-stream": "1.1.14"
+			}
+		},
+		"streamsearch": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+			"integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+		},
+		"string-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
+			"integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+			"dev": true,
+			"requires": {
+				"strip-ansi": "3.0.1"
+			}
+		},
+		"string-width": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"requires": {
+				"code-point-at": "1.1.0",
+				"is-fullwidth-code-point": "1.0.0",
+				"strip-ansi": "3.0.1"
+			}
+		},
+		"string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"strip-bom": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"dev": true,
+			"requires": {
+				"is-utf8": "0.2.1"
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
+		},
+		"temp": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+			"requires": {
+				"os-tmpdir": "1.0.2",
+				"rimraf": "2.2.8"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.2.8",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+				}
+			}
+		},
+		"term-size": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+			"dev": true,
+			"requires": {
+				"execa": "0.7.0"
+			}
+		},
+		"test-exclude": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+			"integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
+			"dev": true,
+			"requires": {
+				"arrify": "1.0.1",
+				"micromatch": "2.3.11",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"require-main-filename": "1.0.1"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"dev": true
+				}
+			}
+		},
+		"throat": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
+			"integrity": "sha1-UMsGcO28QCN7njR9fh+I5GIK+DY=",
+			"dev": true
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+		},
+		"through2": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"requires": {
+				"readable-stream": "2.3.3",
+				"xtend": "4.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
+		"time-stamp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+		},
+		"timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+			"dev": true
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"requires": {
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+		},
+		"to-fast-properties": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+		},
+		"touch": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+			"integrity": "sha1-/jZfX3XsntTlaCXgu3bSSrdK+Ds=",
+			"dev": true,
+			"requires": {
+				"nopt": "1.0.10"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+		},
+		"tsscmp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
+			"integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc="
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"type-is": {
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+			"integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "2.1.17"
+			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+		},
+		"ua-parser-js": {
+			"version": "0.7.14",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
+			"integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
+		},
+		"uglify-js": {
+			"version": "2.7.5",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+			"integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"async": "0.2.10",
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "0.2.10",
+					"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+					"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+					"dev": true,
+					"optional": true
+				},
+				"yargs": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
+						"window-size": "0.1.0"
+					}
+				}
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
+			"optional": true
+		},
+		"uid-safe": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
+			"integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
+			"requires": {
+				"random-bytes": "1.0.0"
+			}
+		},
+		"ultron": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+			"integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+		},
+		"undefsafe": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
+			"integrity": "sha1-7Mo6A+VrmvFzhbqsgSrIO5lKli8=",
+			"dev": true
+		},
+		"unique-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"dev": true,
+			"requires": {
+				"crypto-random-string": "1.0.0"
+			}
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+		},
+		"unzip-response": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+			"dev": true
+		},
+		"update-notifier": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
+			"integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
+			"dev": true,
+			"requires": {
+				"boxen": "1.2.1",
+				"chalk": "1.1.3",
+				"configstore": "3.1.1",
+				"import-lazy": "2.1.0",
+				"is-npm": "1.0.0",
+				"latest-version": "3.1.0",
+				"semver-diff": "2.1.0",
+				"xdg-basedir": "3.0.0"
+			}
+		},
+		"url-parse-lax": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"dev": true,
+			"requires": {
+				"prepend-http": "1.0.4"
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+		},
+		"uuid": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+			"integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"requires": {
+				"spdx-correct": "1.0.2",
+				"spdx-expression-parse": "1.0.4"
+			}
+		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			}
+		},
+		"vhost": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
+			"integrity": "sha1-L7HezUxGaqiLD5NBrzPcGv8keNU="
+		},
+		"vinyl": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+			"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+			"requires": {
+				"clone": "1.0.3",
+				"clone-stats": "0.0.1",
+				"replace-ext": "0.0.1"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"requires": {
+				"makeerror": "1.0.11"
+			}
+		},
+		"watch": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
+			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
+			"dev": true
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
+			"dev": true
+		},
+		"whatwg-encoding": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
+			"integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
+			"dev": true,
+			"requires": {
+				"iconv-lite": "0.4.13"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.4.13",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+					"integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+					"dev": true
+				}
+			}
+		},
+		"whatwg-fetch": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+		},
+		"whatwg-url": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+			"integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+			"dev": true,
+			"requires": {
+				"tr46": "0.0.3",
+				"webidl-conversions": "3.0.1"
+			},
+			"dependencies": {
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+					"dev": true
+				}
+			}
+		},
+		"which": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+			"integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+			"requires": {
+				"isexe": "2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+			"dev": true
+		},
+		"widest-line": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+			"integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+			"dev": true,
+			"requires": {
+				"string-width": "1.0.2"
+			}
+		},
+		"win-release": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+			"integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+			"requires": {
+				"semver": "5.4.1"
+			}
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true,
+			"optional": true
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+		},
+		"worker-farm": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz",
+			"integrity": "sha1-rf3wzUBYFGXtCh9kj5c1cir9XI0=",
+			"dev": true,
+			"requires": {
+				"errno": "0.1.4",
+				"xtend": "4.0.1"
+			}
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write-file-atomic": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"slide": "1.1.6"
+			}
+		},
+		"ws": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+			"integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+			"requires": {
+				"options": "0.0.6",
+				"ultron": "1.0.2"
+			}
+		},
+		"xcode": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/xcode/-/xcode-0.9.3.tgz",
+			"integrity": "sha1-kQqJwWrubMC0LKgFptC0z4chHPM=",
+			"requires": {
+				"pegjs": "0.10.0",
+				"simple-plist": "0.2.1",
+				"uuid": "3.0.1"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+				}
+			}
+		},
+		"xdg-basedir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+			"dev": true
+		},
+		"xml-name-validator": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+			"dev": true
+		},
+		"xmlbuilder": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
+			"integrity": "sha1-mLj2UcowqmJANvEn0RzGbce5B6M=",
+			"requires": {
+				"lodash": "3.10.1"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "3.10.1",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+				}
+			}
+		},
+		"xmldoc": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-0.4.0.tgz",
+			"integrity": "sha1-0lciS+g5PqrL+DfvIn/Y7CWzaIg=",
+			"requires": {
+				"sax": "1.1.6"
+			}
+		},
+		"xmldom": {
+			"version": "0.1.27",
+			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+			"integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+		},
+		"xpipe": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/xpipe/-/xpipe-1.0.5.tgz",
+			"integrity": "sha1-jdi/Rfw/f1Xw4FS4ePQ6YmFNr98="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"y18n": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+		},
+		"yargs": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+			"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+			"requires": {
+				"camelcase": "4.1.0",
+				"cliui": "3.2.0",
+				"decamelize": "1.2.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"read-pkg-up": "2.0.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "7.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"requires": {
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+			"requires": {
+				"camelcase": "4.1.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				}
+			}
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6500,7 +6500,9 @@
 			}
 		},
 		"react-native-background-upload": {
-			"version": "file:../react-native-background-upload"
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/react-native-background-upload/-/react-native-background-upload-4.2.0.tgz",
+			"integrity": "sha512-gUDlXkG3wpIy4htzhaAXMltWvKjOOpsA14BxIQaFBbqpHvZaFQTzOqEiWDo/kOzwOCGwvxOXYhCTh/VwvaVA5A=="
 		},
 		"react-native-image-picker": {
 			"version": "0.26.7",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
 		"express": "^4.15.3",
 		"multer": "^1.3.0",
 		"raw-body": "^2.2.0",
-		"react": "16.0.0-alpha.12",
-		"react-native": "0.45.1",
-		"react-native-background-upload": "^4.1.0",
+		"react": "^16.2.0",
+		"react-native": "^0.52.2",
+		"react-native-background-upload": "file:../react-native-background-upload",
 		"react-native-image-picker": "^0.26.3",
 		"uuid": "^3.1.0"
 	},

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"raw-body": "^2.2.0",
 		"react": "^16.2.0",
 		"react-native": "^0.52.2",
-		"react-native-background-upload": "file:../react-native-background-upload",
+		"react-native-background-upload": "^4.2.0",
 		"react-native-image-picker": "^0.26.3",
 		"uuid": "^3.1.0"
 	},


### PR DESCRIPTION
1. Upgraded to latest React Native, 0.52.2.  Required a react package bump
1. Upgraded to latest react-native-background-uploader
1. Removed gradle command to resolve an okhttp version because that issue has been resolved with the latest React Native update
1. Added documentation to readme for forwarding the server port 3000 and how to run this with a local clone of the react-native-background-upload repo.